### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-with-node.yml
+++ b/.github/workflows/build-with-node.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cetracker/cetrack-frontend/security/code-scanning/1](https://github.com/cetracker/cetrack-frontend/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. For a typical Node.js CI workflow that only checks out code and runs builds/tests, `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies to a specific job). The best practice is to add the following block near the top of the workflow file, after the `name` key and before the `on` key:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed. Only the workflow YAML file needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
