### PR TITLE
CE-0002 Sort parts and part-type dropdowns alphabetically

### DIFF
--- a/src/components/partTypes/AddPartToTypeDialog.tsx
+++ b/src/components/partTypes/AddPartToTypeDialog.tsx
@@ -105,7 +105,10 @@ export const AddPartToTypeDialog = ({ open, onClose, partType }: Props) => {
               error={!!errors.partId}
               helperText={errors.partId?.message}
             >
-              {(parts ?? []).map((p) => (
+              {(parts ?? [])
+                .slice()
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((p) => (
                 <MenuItem key={p.id} value={p.id}>
                   {p.name}
                 </MenuItem>

--- a/src/components/parts/RelationForm.tsx
+++ b/src/components/parts/RelationForm.tsx
@@ -204,7 +204,14 @@ export const RelationForm = ({
                 },
               }}
             >
-              {(partTypes ?? []).map((pt) => (
+              {(partTypes ?? [])
+                .slice()
+                .sort(
+                  (a, b) =>
+                    a.name.localeCompare(b.name) ||
+                    bikeName(a.bike).localeCompare(bikeName(b.bike)),
+                )
+                .map((pt) => (
                 <MenuItem key={pt.id} value={pt.id}>
                   {pt.name}
                   {pt.bike ? ` — ${bikeName(pt.bike)}` : ''}


### PR DESCRIPTION
API returns items in insertion order; users need a predictable list. Part types in RelationForm sort by name, then by bike name as tiebreaker. Parts in AddPartToTypeDialog sort by name.

[Claude Code - model: claude-sonnet-4-6]